### PR TITLE
Corrected link to the ova-client git repository.

### DIFF
--- a/source/start.rst
+++ b/source/start.rst
@@ -4,7 +4,7 @@ Quick Start
 
 The OVA server is deployed in this address https://api.openvisionapi.com, To give it a quick try, visit the client repository:
 
-https://github.com/openvisionapi/client
+https://github.com/openvisionapi/ova-client
 
 installation
 ============


### PR DESCRIPTION
I have no idea if this is all that needs to be done, but I noticed that the link to the ova-client was wrong.